### PR TITLE
fix(ast): strip the newlines from the svg (closes #21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.0.1
 Fixed default value of `include` to `['**/*.svg']`
 Fixed parsing SVG files with non-root SVG nodes.
+Strip newlines from the transformed ast
 
 ## 3.0.0
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export default function InlineSvg(options: InlineSvgOptions = {}) {
 
     transform(code: string, id: string) {
       if(!filter(id)) return;
-      return {code: `export default '${SvgProcessor.process(code, {...options, fileName: id})}'`, map: {mappings: ''}};
+      return {code: `export default '${SvgProcessor.process(code, {...options, fileName: id}).replace(/\n/g, '')}'`, map: {mappings: ''}};
     },
   };
 }


### PR DESCRIPTION
https://github.com/sionzee/rollup-plugin-inline-svg/issues/21